### PR TITLE
feat: OCR support for images and scanned PDFs

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -15,6 +15,7 @@ import {
   DocxExtractor,
   WebExtractor,
   CodeExtractor,
+  ImageExtractor,
 } from "@emdzej/ragclaw-core";
 import type { Source, Extractor, ChunkRecord, Chunker } from "@emdzej/ragclaw-core";
 import { getDbPath, RAGCLAW_DIR } from "../config.js";
@@ -63,6 +64,7 @@ export async function addCommand(source: string, options: AddOptions): Promise<v
     new DocxExtractor(),
     new WebExtractor(),
     new CodeExtractor(),
+    new ImageExtractor(),
     new TextExtractor(), // Fallback, keep last
   ];
   const semanticChunker = new SemanticChunker();
@@ -232,6 +234,7 @@ async function collectFilesRecursive(dir: string, options: AddOptions): Promise<
       const supportedExts = [
         ".md", ".markdown", ".mdx", ".txt", ".text", ".pdf", ".docx",
         ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".py", ".go", ".java",
+        ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif",
       ];
       if (supportedExts.includes(ext)) {
         sources.push({ type: "file", path: fullPath });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,9 +20,11 @@
   "dependencies": {
     "@xenova/transformers": "^2.17.0",
     "better-sqlite3": "^11.8.0",
+    "canvas": "^3.2.1",
     "cheerio": "^1.2.0",
     "mammoth": "^1.12.0",
     "pdfjs-dist": "^5.5.207",
+    "tesseract.js": "^7.0.0",
     "tree-sitter": "^0.25.0",
     "tree-sitter-go": "^0.25.0",
     "tree-sitter-java": "^0.23.5",

--- a/packages/core/src/extractors/image.ts
+++ b/packages/core/src/extractors/image.ts
@@ -1,0 +1,83 @@
+import { basename, extname } from "path";
+import Tesseract from "tesseract.js";
+import type { Extractor, ExtractedContent, Source } from "../types.js";
+
+const IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif"];
+
+export class ImageExtractor implements Extractor {
+  private language: string;
+
+  constructor(language = "eng") {
+    this.language = language;
+  }
+
+  canHandle(source: Source): boolean {
+    if (source.type !== "file" || !source.path) return false;
+    const ext = extname(source.path).toLowerCase();
+    return IMAGE_EXTENSIONS.includes(ext);
+  }
+
+  async extract(source: Source): Promise<ExtractedContent> {
+    if (!source.path) {
+      throw new Error("ImageExtractor requires a file path");
+    }
+
+    const result = await Tesseract.recognize(source.path, this.language, {
+      logger: () => {}, // Suppress progress logs
+    });
+
+    const text = result.data.text.trim();
+    const confidence = result.data.confidence;
+
+    const metadata: Record<string, unknown> = {
+      filename: basename(source.path),
+      ocrConfidence: confidence,
+      language: this.language,
+    };
+
+    // Extract any detected paragraphs/blocks info
+    if (result.data.blocks) {
+      metadata.blocks = result.data.blocks.length;
+    }
+
+    return {
+      text,
+      metadata,
+      sourceType: "text", // Treat OCR output as plain text
+      mimeType: this.getMimeType(source.path),
+    };
+  }
+
+  private getMimeType(path: string): string {
+    const ext = extname(path).toLowerCase();
+    switch (ext) {
+      case ".png": return "image/png";
+      case ".jpg":
+      case ".jpeg": return "image/jpeg";
+      case ".gif": return "image/gif";
+      case ".webp": return "image/webp";
+      case ".bmp": return "image/bmp";
+      case ".tiff":
+      case ".tif": return "image/tiff";
+      default: return "image/unknown";
+    }
+  }
+}
+
+/**
+ * Run OCR on an image buffer and return extracted text.
+ * Useful for PDF pages that are image-only.
+ */
+export async function ocrFromBuffer(
+  buffer: Buffer,
+  language = "eng"
+): Promise<{ text: string; confidence: number }> {
+  const result = await Tesseract.recognize(buffer, language, {
+    logger: () => {},
+  });
+
+  return {
+    text: result.data.text.trim(),
+    confidence: result.data.confidence,
+  };
+}

--- a/packages/core/src/extractors/pdf.ts
+++ b/packages/core/src/extractors/pdf.ts
@@ -2,7 +2,18 @@ import { readFile } from "fs/promises";
 import { basename, extname } from "path";
 import type { Extractor, ExtractedContent, Source } from "../types.js";
 
+// Minimum text length per page to consider it "has text"
+const MIN_TEXT_PER_PAGE = 50;
+
 export class PdfExtractor implements Extractor {
+  private enableOcr: boolean;
+  private ocrLanguage: string;
+
+  constructor(options: { enableOcr?: boolean; ocrLanguage?: string } = {}) {
+    this.enableOcr = options.enableOcr ?? true;
+    this.ocrLanguage = options.ocrLanguage ?? "eng";
+  }
+
   canHandle(source: Source): boolean {
     if (source.type !== "file" || !source.path) return false;
     const ext = extname(source.path).toLowerCase();
@@ -23,20 +34,49 @@ export class PdfExtractor implements Extractor {
     const numPages = doc.numPages;
     
     const textParts: string[] = [];
+    let ocrPages = 0;
+    let usedOcr = false;
     
     for (let i = 1; i <= numPages; i++) {
       const page = await doc.getPage(i);
       const textContent = await page.getTextContent();
       const pageText = textContent.items
         .map((item) => "str" in item ? item.str : "")
-        .join(" ");
-      textParts.push(pageText);
+        .join(" ")
+        .trim();
+      
+      // Check if page has meaningful text
+      if (pageText.length >= MIN_TEXT_PER_PAGE) {
+        textParts.push(pageText);
+      } else if (this.enableOcr) {
+        // Page appears to be an image/scan - try OCR
+        try {
+          const ocrText = await this.ocrPage(page, pdfjs);
+          if (ocrText.length > 0) {
+            textParts.push(ocrText);
+            ocrPages++;
+            usedOcr = true;
+          }
+        } catch {
+          // OCR failed, skip this page
+          if (pageText.length > 0) {
+            textParts.push(pageText);
+          }
+        }
+      } else if (pageText.length > 0) {
+        textParts.push(pageText);
+      }
     }
 
     const metadata: Record<string, unknown> = {
       filename: basename(source.path),
       pages: numPages,
     };
+
+    if (usedOcr) {
+      metadata.ocrPages = ocrPages;
+      metadata.ocrLanguage = this.ocrLanguage;
+    }
 
     // Try to get PDF metadata
     try {
@@ -56,5 +96,32 @@ export class PdfExtractor implements Extractor {
       sourceType: "pdf",
       mimeType: "application/pdf",
     };
+  }
+
+  private async ocrPage(page: unknown, pdfjs: unknown): Promise<string> {
+    // Cast to any for simpler typing
+    const p = page as { getViewport: (opts: { scale: number }) => { width: number; height: number }; render: (opts: unknown) => { promise: Promise<void> } };
+    
+    // Render page to canvas and extract image
+    const viewport = p.getViewport({ scale: 2.0 }); // Higher scale = better OCR
+    
+    // Create a canvas for Node.js
+    const { createCanvas } = await import("canvas");
+    const canvas = createCanvas(viewport.width, viewport.height);
+    const context = canvas.getContext("2d");
+
+    await p.render({
+      canvasContext: context as never,
+      viewport,
+    }).promise;
+
+    // Convert to PNG buffer
+    const pngBuffer = canvas.toBuffer("image/png");
+
+    // Run OCR
+    const { ocrFromBuffer } = await import("./image.js");
+    const result = await ocrFromBuffer(pngBuffer, this.ocrLanguage);
+    
+    return result.text;
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export { PdfExtractor } from "./extractors/pdf.js";
 export { DocxExtractor } from "./extractors/docx.js";
 export { WebExtractor } from "./extractors/web.js";
 export { CodeExtractor } from "./extractors/code.js";
+export { ImageExtractor, ocrFromBuffer } from "./extractors/image.js";
 
 // Utils
 export { cosineSimilarity } from "./utils/math.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       better-sqlite3:
         specifier: ^11.8.0
         version: 11.10.0
+      canvas:
+        specifier: ^3.2.1
+        version: 3.2.1
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
@@ -54,6 +57,9 @@ importers:
       pdfjs-dist:
         specifier: ^5.5.207
         version: 5.5.207
+      tesseract.js:
+        specifier: ^7.0.0
+        version: 7.0.0
       tree-sitter:
         specifier: ^0.25.0
         version: 0.25.0
@@ -688,6 +694,9 @@ packages:
   bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
+  bmp-js@0.1.0:
+    resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -713,6 +722,10 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  canvas@3.2.1:
+    resolution: {integrity: sha512-ej1sPFR5+0YWtaVp6S1N1FVz69TQCqmrkGeRvQxZeAB1nAIcjNTHVwrZtYtWFFBmQsF40/uDLehsW5KuYC99mg==}
+    engines: {node: ^18.12.0 || >= 20.9.0}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -1031,6 +1044,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  idb-keyval@6.2.2:
+    resolution: {integrity: sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -1068,6 +1084,9 @@ packages:
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
+
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -1170,9 +1189,21 @@ packages:
   node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-addon-api@8.6.0:
     resolution: {integrity: sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==}
     engines: {node: ^18 || ^20 || >= 21}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -1215,6 +1246,10 @@ packages:
 
   onnxruntime-web@1.14.0:
     resolution: {integrity: sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==}
+
+  opencollective-postinstall@2.0.3:
+    resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
+    hasBin: true
 
   option@0.2.4:
     resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
@@ -1321,6 +1356,9 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1472,6 +1510,12 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
+  tesseract.js-core@7.0.0:
+    resolution: {integrity: sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==}
+
+  tesseract.js@7.0.0:
+    resolution: {integrity: sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==}
+
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
@@ -1500,6 +1544,9 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tree-sitter-go@0.25.0:
     resolution: {integrity: sha512-APBc/Dq3xz/e35Xpkhb1blu5UgW+2E3RyGWawZSCNcbGwa7jhSQPS8KsUupuzBla8PCo8+lz9W/JDJjmfRa2tw==}
@@ -1666,6 +1713,12 @@ packages:
       jsdom:
         optional: true
 
+  wasm-feature-detect@1.8.0:
+    resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
@@ -1674,6 +1727,9 @@ packages:
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1691,6 +1747,9 @@ packages:
   xmlbuilder@10.1.1:
     resolution: {integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==}
     engines: {node: '>=4.0'}
+
+  zlibjs@0.3.1:
+    resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -2129,6 +2188,8 @@ snapshots:
 
   bluebird@3.4.7: {}
 
+  bmp-js@0.1.0: {}
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -2163,6 +2224,11 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  canvas@3.2.1:
+    dependencies:
+      node-addon-api: 7.1.1
+      prebuild-install: 7.1.3
 
   chai@5.3.3:
     dependencies:
@@ -2517,6 +2583,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  idb-keyval@6.2.2: {}
+
   ieee754@1.2.1: {}
 
   immediate@3.0.6: {}
@@ -2538,6 +2606,8 @@ snapshots:
   is-unicode-supported@1.3.0: {}
 
   is-unicode-supported@2.1.0: {}
+
+  is-url@1.2.4: {}
 
   isarray@1.0.0: {}
 
@@ -2628,7 +2698,13 @@ snapshots:
 
   node-addon-api@6.1.0: {}
 
+  node-addon-api@7.1.1: {}
+
   node-addon-api@8.6.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-gyp-build@4.8.4: {}
 
@@ -2674,6 +2750,8 @@ snapshots:
       onnx-proto: 4.0.4
       onnxruntime-common: 1.14.0
       platform: 1.3.6
+
+  opencollective-postinstall@2.0.3: {}
 
   option@0.2.4: {}
 
@@ -2813,6 +2891,8 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  regenerator-runtime@0.13.11: {}
 
   require-from-string@2.0.2: {}
 
@@ -3054,6 +3134,22 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  tesseract.js-core@7.0.0: {}
+
+  tesseract.js@7.0.0:
+    dependencies:
+      bmp-js: 0.1.0
+      idb-keyval: 6.2.2
+      is-url: 1.2.4
+      node-fetch: 2.7.0
+      opencollective-postinstall: 2.0.3
+      regenerator-runtime: 0.13.11
+      tesseract.js-core: 7.0.0
+      wasm-feature-detect: 1.8.0
+      zlibjs: 0.3.1
+    transitivePeerDependencies:
+      - encoding
+
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.0
@@ -3076,6 +3172,8 @@ snapshots:
   tinyspy@4.0.4: {}
 
   toidentifier@1.0.1: {}
+
+  tr46@0.0.3: {}
 
   tree-sitter-go@0.25.0(tree-sitter@0.25.0):
     dependencies:
@@ -3234,11 +3332,20 @@ snapshots:
       - tsx
       - yaml
 
+  wasm-feature-detect@1.8.0: {}
+
+  webidl-conversions@3.0.1: {}
+
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
 
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:
@@ -3252,6 +3359,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   xmlbuilder@10.1.1: {}
+
+  zlibjs@0.3.1: {}
 
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
## Implements Issue #23

### New Features
- **ImageExtractor** — OCR for .png, .jpg, .jpeg, .gif, .webp, .bmp, .tiff
- **Enhanced PdfExtractor** — Auto-detects scanned pages and runs OCR

### How It Works
1. For images: Direct OCR via tesseract.js
2. For PDFs: Extract text normally, if page has <50 chars → render to canvas → OCR

### Dependencies
- `tesseract.js` — Pure JS OCR engine (offline, no native deps)
- `canvas` — PDF page rendering for OCR

### Usage
```bash
ragclaw add ./scanned-document.pdf
ragclaw add ./receipt.jpg
ragclaw add ./screenshots/
```

### Metadata
- `ocrConfidence` — Tesseract confidence score (0-100)
- `ocrPages` — Number of pages processed with OCR (PDFs)
- `ocrLanguage` — Language used (default: eng)

### Notes
- First OCR downloads ~15MB language data (cached in `~/.cache/tesseract`)
- Higher resolution images = better OCR accuracy

Closes #23