### PR TITLE
feat: Incremental reindex command

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,7 @@ import { searchCommand } from "./commands/search.js";
 import { statusCommand } from "./commands/status.js";
 import { listCommand } from "./commands/list.js";
 import { removeCommand } from "./commands/remove.js";
+import { reindex } from "./commands/reindex.js";
 
 const program = new Command();
 
@@ -62,5 +63,13 @@ program
   .option("-d, --db <name>", "Knowledge base name", "default")
   .option("-y, --yes", "Skip confirmation")
   .action(removeCommand);
+
+program
+  .command("reindex")
+  .description("Re-process changed sources")
+  .option("-d, --db <name>", "Knowledge base name", "default")
+  .option("-f, --force", "Reindex all sources regardless of hash")
+  .option("-p, --prune", "Remove sources that no longer exist")
+  .action((options) => reindex(options));
 
 program.parse();

--- a/packages/cli/src/commands/reindex.ts
+++ b/packages/cli/src/commands/reindex.ts
@@ -1,0 +1,194 @@
+import { existsSync } from "fs";
+import { stat, readFile } from "fs/promises";
+import { createHash } from "crypto";
+import ora from "ora";
+import chalk from "chalk";
+import {
+  Store,
+  Embedder,
+  SemanticChunker,
+  CodeChunker,
+  MarkdownExtractor,
+  TextExtractor,
+  PdfExtractor,
+  DocxExtractor,
+  WebExtractor,
+  CodeExtractor,
+  ImageExtractor,
+} from "@emdzej/ragclaw-core";
+import type { Extractor, Chunker, ChunkRecord } from "@emdzej/ragclaw-core";
+import { getDbPath } from "../config.js";
+
+interface ReindexOptions {
+  db: string;
+  force?: boolean;
+  prune?: boolean;
+}
+
+interface ReindexResult {
+  updated: number;
+  unchanged: number;
+  removed: number;
+  errors: string[];
+}
+
+export async function reindex(options: ReindexOptions): Promise<void> {
+  const dbPath = getDbPath(options.db);
+
+  if (!existsSync(dbPath)) {
+    console.log(chalk.red(`Knowledge base "${options.db}" not found.`));
+    console.log(chalk.dim(`Run: ragclaw add <source> -d ${options.db}`));
+    return;
+  }
+
+  const spinner = ora("Loading knowledge base...").start();
+
+  const store = new Store();
+  await store.open(dbPath);
+
+  try {
+    const sources = await store.listSources();
+
+    if (sources.length === 0) {
+      spinner.info("No sources to reindex.");
+      return;
+    }
+
+    spinner.text = "Loading embedding model...";
+    const embedder = new Embedder();
+    await embedder.embed("warmup");
+    spinner.succeed("Model loaded");
+
+    const extractors: Extractor[] = [
+      new MarkdownExtractor(),
+      new PdfExtractor(),
+      new DocxExtractor(),
+      new WebExtractor(),
+      new CodeExtractor(),
+      new ImageExtractor(),
+      new TextExtractor(),
+    ];
+    const semanticChunker = new SemanticChunker();
+    const codeChunker = new CodeChunker();
+
+    const result: ReindexResult = {
+      updated: 0,
+      unchanged: 0,
+      removed: 0,
+      errors: [],
+    };
+
+    for (const source of sources) {
+      const displayPath = source.path.length > 60
+        ? "..." + source.path.slice(-57)
+        : source.path;
+
+      spinner.text = `Checking ${displayPath}`;
+
+      try {
+        // Check if source still exists
+        const isUrl = source.type === "url";
+        
+        if (!isUrl && !existsSync(source.path)) {
+          if (options.prune) {
+            await store.removeSource(source.id);
+            result.removed++;
+            console.log(chalk.yellow(`✗ Removed (not found): ${displayPath}`));
+          } else {
+            console.log(chalk.dim(`⊘ Missing: ${displayPath}`));
+          }
+          continue;
+        }
+
+        // Calculate current hash
+        let currentHash: string | undefined;
+        let currentMtime: number | undefined;
+
+        if (!isUrl) {
+          const content = await readFile(source.path, "utf-8").catch(() =>
+            readFile(source.path).then((b) => b.toString("base64"))
+          );
+          currentHash = createHash("sha256").update(content).digest("hex");
+          const fileStat = await stat(source.path);
+          currentMtime = fileStat.mtimeMs;
+        }
+
+        // Skip if unchanged (unless --force)
+        if (!options.force && currentHash && currentHash === source.contentHash) {
+          result.unchanged++;
+          continue;
+        }
+
+        // Find extractor
+        const src = isUrl
+          ? { type: "url" as const, url: source.path }
+          : { type: "file" as const, path: source.path };
+
+        const extractor = extractors.find((e) => e.canHandle(src));
+        if (!extractor) {
+          result.errors.push(`${displayPath}: No extractor available`);
+          continue;
+        }
+
+        // Re-extract and re-chunk
+        spinner.text = `Reindexing ${displayPath}`;
+
+        const extracted = await extractor.extract(src);
+        const chunker: Chunker = extracted.sourceType === "code" ? codeChunker : semanticChunker;
+        const chunks = await chunker.chunk(extracted, source.id, source.path);
+        const embeddings = await embedder.embedBatch(chunks.map((c) => c.text));
+
+        // Remove old chunks
+        await store.removeChunksBySource(source.id);
+
+        // Update source metadata
+        const now = Date.now();
+        await store.updateSource(source.id, {
+          contentHash: currentHash,
+          mtime: currentMtime,
+          indexedAt: now,
+          metadata: extracted.metadata,
+        });
+
+        // Add new chunks
+        const chunkRecords: ChunkRecord[] = chunks.map((chunk, i) => ({
+          ...chunk,
+          sourceId: source.id,
+          embedding: embeddings[i],
+          createdAt: now,
+        }));
+
+        await store.addChunks(chunkRecords);
+        result.updated++;
+        console.log(chalk.green(`✔ Updated: ${displayPath} (${chunkRecords.length} chunks)`));
+
+      } catch (err) {
+        result.errors.push(`${displayPath}: ${err}`);
+        console.log(chalk.red(`✖ Error: ${displayPath}`));
+      }
+    }
+
+    spinner.stop();
+
+    // Summary
+    console.log("");
+    console.log(chalk.bold("Reindex complete:"));
+    console.log(`  ${chalk.green("Updated:")} ${result.updated}`);
+    console.log(`  ${chalk.dim("Unchanged:")} ${result.unchanged}`);
+    if (result.removed > 0) {
+      console.log(`  ${chalk.yellow("Removed:")} ${result.removed}`);
+    }
+    if (result.errors.length > 0) {
+      console.log(`  ${chalk.red("Errors:")} ${result.errors.length}`);
+      for (const err of result.errors.slice(0, 5)) {
+        console.log(chalk.red(`    ${err}`));
+      }
+      if (result.errors.length > 5) {
+        console.log(chalk.dim(`    ... and ${result.errors.length - 5} more`));
+      }
+    }
+
+  } finally {
+    await store.close();
+  }
+}


### PR DESCRIPTION
## Implements Issue #25

### New Command
```bash
ragclaw reindex [--db <name>] [--force] [--prune]
```

### Features
- **Incremental by default** — only re-processes files with changed SHA256 hash
- **--force** — reindex all sources regardless of hash
- **--prune** — remove sources that no longer exist on disk

### How It Works
1. Iterate all indexed sources
2. Check if file still exists (mark for removal if --prune)
3. Compare current SHA256 hash with stored hash
4. Skip unchanged, re-extract & re-embed changed
5. Report summary: updated, unchanged, removed

### Use Cases
- After upgrading extractors (better parsing)
- After changing chunking strategy
- Periodic maintenance
- Clean up deleted files with --prune

### Example Output
```
✔ Model loaded
✔ Updated: ./src/index.ts (3 chunks)
⊘ Missing: ./deleted-file.md

Reindex complete:
  Updated: 1
  Unchanged: 15
```

Closes #25